### PR TITLE
feature/get-column-type-names

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -309,6 +309,27 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
                            0,
                            NULL,
                            &columns[i].type);
+
+    //get the estimated size of column type name
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_TYPE_NAME,
+                           NULL,
+                           NULL,
+                           (SQLSMALLINT *) &buflen,
+                           NULL);
+
+    SQLSMALLINT estimatedSize = buflen + 2;
+    columns[i].typeName = new unsigned char[estimatedSize];
+
+    // get the column type name
+    ret = SQLColAttribute( hStmt,
+                           columns[i].index,
+                           SQL_DESC_TYPE_NAME,
+                           columns[i].typeName,
+                           estimatedSize,
+                           (SQLSMALLINT *) &buflen,
+                           NULL);
   }
   
   return columns;
@@ -321,6 +342,7 @@ Column* ODBC::GetColumns(SQLHSTMT hStmt, short* colCount) {
 void ODBC::FreeColumns(Column* columns, short* colCount) {
   for(int i = 0; i < *colCount; i++) {
       delete [] columns[i].name;
+      delete [] columns[i].typeName;
   }
 
   delete [] columns;

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -57,6 +57,7 @@ using namespace node;
 typedef struct {
   unsigned char *name;
   unsigned int len;
+  unsigned char *typeName;
   SQLLEN type;
   SQLUSMALLINT index;
 } Column;


### PR DESCRIPTION
Get column type names when getting column attributes for result set. Will be useful when conveying metadata to clients.