### PR TITLE
fix/set fetch mode on result instances

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -292,7 +292,11 @@ Database.prototype.queryResult = function (sql, params, cb) {
         return next();
       }
 
-      if (self.fetchMode) {
+      if (typeof (sql) === 'object') {
+        result.fetchMode = sql.fetchMode || null;
+      }
+
+      if (!result.fetchMode && self.fetchMode) {
         result.fetchMode = self.fetchMode;
       }
 
@@ -317,7 +321,11 @@ Database.prototype.queryResultSync = function (sql, params) {
     result = self.conn.querySync(sql);
   }
 
-  if (self.fetchMode) {
+  if (typeof (sql) === 'object') {
+    result.fetchMode = sql.fetchMode || null;
+  }
+
+  if (!result.fetchMode && self.fetchMode) {
     result.fetchMode = self.fetchMode;
   }
 


### PR DESCRIPTION
Fixes the fetch mode option being ignored when used with the `queryResult` methods. The returned `ODBCResult` now has the fetch mode set to the option (if it was specified).