### PR TITLE
refactor/reduce-column-name-memory-use

### DIFF
--- a/src/odbc.h
+++ b/src/odbc.h
@@ -55,8 +55,7 @@ using namespace node;
 
 
 typedef struct {
-  unsigned char *name;
-  unsigned int len;
+  uint8_t *name;
   uint8_t *typeName;
   SQLLEN type;
   SQLUSMALLINT index;

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -805,8 +805,13 @@ NAN_METHOD(ODBCResult::GetColumnNamesSync) {
   }
   
   for (int i = 0; i < self->colCount; i++) {
+#ifdef UNICODE
+    cols->Set(Nan::New(i),
+              Nan::New((const uint16_t *) self->columns[i].name).ToLocalChecked());
+#else
     cols->Set(Nan::New(i),
               Nan::New((const char *) self->columns[i].name).ToLocalChecked());
+#endif
   }
     
   info.GetReturnValue().Set(cols);


### PR DESCRIPTION
Reduce the memory allocated when retrieving column name.